### PR TITLE
docs: fix typo with environment variable definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add CIRCLECI_COMPARE_URL environment to your .circleci/config.yml
 
 ```jsx
 environment:
-    CIRCLE_COMPARE_URL: << pipeline.project.git_url >>/compare/<< pipeline.git.base_revision >>...<<pipeline.git.revision>>
+    CIRCLECI_COMPARE_URL: << pipeline.project.git_url >>/compare/<< pipeline.git.base_revision >>...<<pipeline.git.revision>>
 ```
 
 ### Get files to be tested by jest


### PR DESCRIPTION
Hi there, seems like there's a type with the environment variable to be created in circle ci, the PR  fixes that.